### PR TITLE
Add security options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@ This module creates an Azure compute gallery optionally seeded with image defini
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.11.0 |
 
-## Modules
-
-No modules.
-
 ## Resources
 
 | Name | Type |
@@ -31,17 +27,17 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_image_definitions"></a> [image\_definitions](#input\_image\_definitions) | VM image definitions to create in the gallery. | <pre>list(object({<br>    name       = string<br>    os_type    = string<br>    offer      = string<br>    sku        = string<br>    app        = string<br>    generation = optional(string, "V2")<br>  }))</pre> | `[]` | no |
-| <a name="input_image_gallery_description"></a> [image\_gallery\_description](#input\_image\_gallery\_description) | Description for the shared image gallery. | `string` | `"Shared images built by Packer."` | no |
-| <a name="input_image_gallery_name"></a> [image\_gallery\_name](#input\_image\_gallery\_name) | Name for the shared image gallery. | `string` | `"packer_images"` | no |
-| <a name="input_location"></a> [location](#input\_location) | The Azure region where resources will be created. | `string` | `"centralus"` | no |
 | <a name="input_publisher"></a> [publisher](#input\_publisher) | Publisher name to use on image definitions. | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of the existing resource group where the gallery will be created. | `string` | n/a | yes |
+| <a name="input_image_definitions"></a> [image\_definitions](#input\_image\_definitions) | VM image definitions to create in the gallery. | <pre>list(object({<br>    name                    = string<br>    os_type                 = string<br>    offer                   = string<br>    sku                     = string<br>    app                     = string<br>    generation              = optional(string, "V2")<br>    trusted_launch_enabled  = optional(bool, true)<br>    confidential_vm_enabled = optional(bool)<br>  }))</pre> | `[]` | no |
+| <a name="input_image_gallery_description"></a> [image\_gallery\_description](#input\_image\_gallery\_description) | Description for the shared image gallery. | `string` | `"Shared images built by Packer."` | no |
+| <a name="input_image_gallery_name"></a> [image\_gallery\_name](#input\_image\_gallery\_name) | Name for the shared image gallery. | `string` | `"packer_images"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | <a name="output_image_gallery_id"></a> [image\_gallery\_id](#output\_image\_gallery\_id) | ID of the created image gallery. |
-| <a name="output_name"></a> [name](#output\_name) | Unique name of the created image gallery. |
+| <a name="output_image_gallery_unique_name"></a> [image\_gallery\_unique\_name](#output\_image\_gallery\_unique\_name) | Unique name of the created image gallery. |
+| <a name="output_shared_images"></a> [shared\_images](#output\_shared\_images) | Shared image definitions. |
 <!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -24,13 +24,16 @@ resource "azurerm_shared_image_gallery" "packer" {
 }
 
 resource "azurerm_shared_image" "packer" {
-  for_each            = { for image in var.image_definitions : image.name => image }
-  name                = each.value.name
-  gallery_name        = azurerm_shared_image_gallery.packer.name
-  resource_group_name = data.azurerm_resource_group.packer.name
-  location            = data.azurerm_resource_group.packer.location
-  os_type             = each.value.os_type
-  hyper_v_generation  = each.value.generation
+  for_each = { for image in var.image_definitions : image.name => image }
+
+  name                    = each.value.name
+  gallery_name            = azurerm_shared_image_gallery.packer.name
+  resource_group_name     = data.azurerm_resource_group.packer.name
+  location                = data.azurerm_resource_group.packer.location
+  os_type                 = each.value.os_type
+  hyper_v_generation      = each.value.generation
+  trusted_launch_enabled  = each.value.trusted_launch_enabled
+  confidential_vm_enabled = each.value.confidential_vm_enabled
 
   identifier {
     publisher = var.publisher

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.3"
+
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/tests/input-validation.tftest.hcl
+++ b/tests/input-validation.tftest.hcl
@@ -1,0 +1,87 @@
+variables {
+  resource_group_name = "packer-images-test"
+  image_gallery_name  = "packer_images_test"
+  publisher           = "HashiCafe-test"
+
+  image_definitions = [
+    {
+      name                    = "ubuntu22-base"
+      os_type                 = "Linux"
+      offer                   = "ubuntu22-base"
+      sku                     = "22_04-lts"
+      app                     = "test"
+    }
+  ]
+}
+
+mock_provider "azurerm" {}
+
+run "default_values" {
+  command = plan
+}
+
+run "invalid_gallery_name" {
+  command = plan
+
+  variables {
+    image_gallery_name = "invalid-name"
+  }
+
+  expect_failures = [var.image_gallery_name]
+}
+
+run "gallery_name_length" {
+  command = plan
+
+  variables {
+    image_gallery_name = "gallery_name_too_long_lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_sed_do"
+  }
+
+  expect_failures = [var.image_gallery_name]
+}
+
+run "invalid_generation" {
+  command = plan
+
+  variables {
+    image_definitions = [
+      {
+        name                    = "ubuntu22-base"
+        os_type                 = "Linux"
+        offer                   = "ubuntu22-base"
+        sku                     = "22_04-lts"
+        app                     = "none"
+
+        # Neither security option is compatible with Gen 1 VMs
+        generation              = "V1"
+        trusted_launch_enabled  = null
+        confidential_vm_enabled = true
+      },
+    ]
+  }
+
+  expect_failures = [var.image_definitions]
+}
+
+run "conflicting_options" {
+  command = plan
+
+  variables {
+    image_definitions = [
+      {
+        name                    = "ubuntu22-base"
+        os_type                 = "Linux"
+        offer                   = "ubuntu22-base"
+        sku                     = "22_04-lts"
+        app                     = "none"
+        generation              = "V2"
+
+        # Both of these cannot have a non-null value
+        trusted_launch_enabled  = true
+        confidential_vm_enabled = false
+      },
+    ]
+  }
+
+  expect_failures = [var.image_definitions]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -7,12 +7,14 @@ variable "image_gallery_name" {
   type        = string
   description = "Name for the shared image gallery."
   default     = "packer_images"
+
   validation {
     condition     = length(var.image_gallery_name) >= 1 && length(var.image_gallery_name) <= 80
     error_message = "Image gallery names must be between 1 and 80 characters."
   }
+
   validation {
-    condition     = can(regex("[a-zA-Z0-9_\\.]+", var.image_gallery_name))
+    condition     = can(regex("^[a-zA-Z0-9_\\.]+$", var.image_gallery_name))
     error_message = "Image gallery names can only contain letters, numbers, underscores, and periods."
   }
 }
@@ -30,13 +32,30 @@ variable "publisher" {
 
 variable "image_definitions" {
   type = list(object({
-    name       = string
-    os_type    = string
-    offer      = string
-    sku        = string
-    app        = string
-    generation = optional(string, "V2")
+    name                    = string
+    os_type                 = string
+    offer                   = string
+    sku                     = string
+    app                     = string
+    generation              = optional(string, "V2")
+    trusted_launch_enabled  = optional(bool, true)
+    confidential_vm_enabled = optional(bool)
   }))
+
   description = "VM image definitions to create in the gallery."
   default     = []
+
+  validation {
+    condition = alltrue([for o in var.image_definitions:
+      anytrue([o.trusted_launch_enabled, o.confidential_vm_enabled]) && o.generation == "V2"
+    ])
+    error_message = "If trusted launch or confidential VM are enabled, `generation` must be `V2`."
+  }
+
+  validation {
+    condition = alltrue([for o in var.image_definitions:
+      ! alltrue([o.trusted_launch_enabled != null, o.confidential_vm_enabled != null])
+    ])
+    error_message = "Only one of `trusted_launch_enabled` or `confidential_vm_enabled` can be set."
+  }
 }


### PR DESCRIPTION
Adds support for requiring Trusted Launch or Confidential VMs to image definitions.

- Adds optional `trusted_launch_enabled` and `confidential_vm_enabled` attributes to the `image_definitions` input object
- Default is to enable Trusted Launch
- These options are mutually exclusive due to the conflicting provider attributes

Also adds input validation tests.