### PR TITLE
Fix handling of security options

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.11.0"
+      version = ">= 3.43.0"
     }
   }
 }
@@ -28,14 +28,18 @@ resource "azurerm_shared_image_gallery" "packer" {
 resource "azurerm_shared_image" "packer" {
   for_each = { for image in var.image_definitions : image.name => image }
 
-  name                    = each.value.name
-  gallery_name            = azurerm_shared_image_gallery.packer.name
-  resource_group_name     = data.azurerm_resource_group.packer.name
-  location                = data.azurerm_resource_group.packer.location
-  os_type                 = each.value.os_type
-  hyper_v_generation      = each.value.generation
-  trusted_launch_enabled  = each.value.trusted_launch_enabled
-  confidential_vm_enabled = each.value.confidential_vm_enabled
+  name                = each.value.name
+  gallery_name        = azurerm_shared_image_gallery.packer.name
+  resource_group_name = data.azurerm_resource_group.packer.name
+  location            = data.azurerm_resource_group.packer.location
+  os_type             = each.value.os_type
+  hyper_v_generation  = each.value.generation
+
+  # Only one of these can have a value
+  trusted_launch_supported  = each.value.security_type == "TrustedLaunchSupported" ? true : null
+  trusted_launch_enabled    = each.value.security_type == "TrustedLaunch" ? true : null
+  confidential_vm_supported = each.value.security_type == "ConfidentialVMSupported" ? true : null
+  confidential_vm_enabled   = each.value.security_type == "ConfidentialVM" ? true : null
 
   identifier {
     publisher = var.publisher

--- a/tests/input-validation.tftest.hcl
+++ b/tests/input-validation.tftest.hcl
@@ -5,11 +5,11 @@ variables {
 
   image_definitions = [
     {
-      name                    = "ubuntu22-base"
-      os_type                 = "Linux"
-      offer                   = "ubuntu22-base"
-      sku                     = "22_04-lts"
-      app                     = "test"
+      name    = "ubuntu22-base"
+      os_type = "Linux"
+      offer   = "ubuntu22-base"
+      sku     = "22_04-lts"
+      app     = "test"
     }
   ]
 }
@@ -18,6 +18,24 @@ mock_provider "azurerm" {}
 
 run "default_values" {
   command = plan
+}
+
+run "gen1_vm" {
+  command = plan
+
+  variables {
+    image_definitions = [
+      {
+        name          = "ubuntu22-base"
+        os_type       = "Linux"
+        offer         = "ubuntu22-base"
+        sku           = "22_04-lts"
+        app           = "test"
+        generation    = "V1"
+        security_type = "Standard"
+      },
+    ]
+  }
 }
 
 run "invalid_gallery_name" {
@@ -46,16 +64,15 @@ run "invalid_generation" {
   variables {
     image_definitions = [
       {
-        name                    = "ubuntu22-base"
-        os_type                 = "Linux"
-        offer                   = "ubuntu22-base"
-        sku                     = "22_04-lts"
-        app                     = "none"
+        name    = "ubuntu22-base"
+        os_type = "Linux"
+        offer   = "ubuntu22-base"
+        sku     = "22_04-lts"
+        app     = "none"
 
-        # Neither security option is compatible with Gen 1 VMs
-        generation              = "V1"
-        trusted_launch_enabled  = null
-        confidential_vm_enabled = true
+        # Only the Standard security type is compatible with Gen 1 VMs
+        generation    = "V1"
+        security_type = "TrustedLaunchSupported"
       },
     ]
   }
@@ -63,22 +80,19 @@ run "invalid_generation" {
   expect_failures = [var.image_definitions]
 }
 
-run "conflicting_options" {
+run "invalid_security_option" {
   command = plan
 
   variables {
     image_definitions = [
       {
-        name                    = "ubuntu22-base"
-        os_type                 = "Linux"
-        offer                   = "ubuntu22-base"
-        sku                     = "22_04-lts"
-        app                     = "none"
-        generation              = "V2"
-
-        # Both of these cannot have a non-null value
-        trusted_launch_enabled  = true
-        confidential_vm_enabled = false
+        name          = "ubuntu22-base"
+        os_type       = "Linux"
+        offer         = "ubuntu22-base"
+        sku           = "22_04-lts"
+        app           = "none"
+        generation    = "V2"
+        security_type = "BadValue"
       },
     ]
   }

--- a/tests/unit-tests.tftest.hcl
+++ b/tests/unit-tests.tftest.hcl
@@ -1,0 +1,41 @@
+variables {
+  resource_group_name = "packer-images-test"
+  image_gallery_name  = "packer_images_test"
+  publisher           = "HashiCafe-test"
+
+  image_definitions = [
+    {
+      name    = "ubuntu22-base"
+      os_type = "Linux"
+      offer   = "ubuntu22-base"
+      sku     = "22_04-lts"
+      app     = "test"
+    }
+  ]
+}
+
+provider "azurerm" {
+  features {}
+}
+
+override_data {
+  target = data.azurerm_resource_group.packer
+  values = {
+    name     = "packer-images-test"
+    location = "CentralUS"
+  }
+}
+
+run "basic_plan" {
+  command = plan
+
+  assert {
+    condition     = azurerm_shared_image_gallery.packer.name == "packer_images_test"
+    error_message = "Gallery name does not match expected."
+  }
+
+  assert {
+    condition     = azurerm_shared_image.packer["ubuntu22-base"].trusted_launch_supported == true
+    error_message = "Default image definition should have `trusted_launch_supported = true`."
+  }
+}


### PR DESCRIPTION
Validating the mutually-exclusive options as object attributes was getting too complicated.

Updated to a single string on the input, and conditionals on the resource

Other changes:

- Updated validations and tests
- Bump provider version constraint for Confidential VM support
- Added basic plan unit test